### PR TITLE
Fix cast type compilation error

### DIFF
--- a/src/EasyGenView.cpp
+++ b/src/EasyGenView.cpp
@@ -1028,7 +1028,7 @@ void CEasyGenView::OnLButtonDblClk(UINT nFlags, CPoint point)
 	CView::OnLButtonDblClk(nFlags, point);
 }
 
-void CEasyGenView::OnTimer(UINT nIDEvent)
+void CEasyGenView::OnTimer(UINT_PTR nIDEvent)
 {
 	CView::OnTimer(nIDEvent);
 /*

--- a/src/EasyGenView.h
+++ b/src/EasyGenView.h
@@ -109,7 +109,7 @@ protected:
 	afx_msg void OnRButtonUp(UINT nFlags, CPoint point);
 	afx_msg void OnKeyDown(UINT nChar, UINT nRepCnt, UINT nFlags);
 	afx_msg void OnLButtonDblClk(UINT nFlags, CPoint point);
-	afx_msg void OnTimer(UINT nIDEvent);
+	afx_msg void OnTimer(UINT_PTR nIDEvent);
 	afx_msg void OnRButtonDblClk(UINT nFlags, CPoint point);
 	afx_msg void OnCameraAlign();
 	afx_msg void OnCameraLeft();


### PR DESCRIPTION
The macro ON_WM_TIMER static casts to
`void (AFX_MSG_CALL CWnd::*)(UINT_PTR)`. This failed with the previous
OnTimer method definition.

Change the parameter type from UINT to UINT_PTR to match the cast.

---

I don’t know if this worked earlier and changed between versions? But it was an issue when trying to compile with my VS 2015 tools, cmake and nmake.